### PR TITLE
pkp/pkp-lib#3836 Fix broken HTML output on registration page.

### DIFF
--- a/OrcidProfilePlugin.inc.php
+++ b/OrcidProfilePlugin.inc.php
@@ -132,7 +132,7 @@ class OrcidProfilePlugin extends GenericPlugin {
 	 * @param $templateMgr TemplateManager
 	 * @return $string
 	 */
-	function registrationFilter($output, &$templateMgr) {
+	function registrationFilter($output, $templateMgr) {
 		if (preg_match('/<form[^>]+id="register"[^>]+>/', $output, $matches, PREG_OFFSET_CAPTURE)) {
 			$match = $matches[0][0];
 			$offset = $matches[0][1];


### PR DESCRIPTION
Fixes a PHP warning that a reference was expected but a value was
passed.