### PR TITLE
Remove old function call "unregister_outputfilter" from Smarty 2

### DIFF
--- a/OrcidProfilePlugin.inc.php
+++ b/OrcidProfilePlugin.inc.php
@@ -346,7 +346,6 @@ class OrcidProfilePlugin extends GenericPlugin {
 			$output = $newOutput;
 			$templateMgr->unregisterFilter('output', array($this, 'authorFormFilter'));
 		}
-		$templateMgr->unregister_outputfilter('profileFilter');
 		return $output;
 	}
 


### PR DESCRIPTION
Hi @asmecher,

during local testing we found another bug, that prevented opening the "Add Contributor" form. The cause was a reference to a removed Smarty function.

Please see the included changes (only one line had to removed).

Thanks for the great work!

Nils