### PR TITLE
Moved all the content into the <form> tag to avoid displaying duplicated content

### DIFF
--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -10,11 +10,6 @@
  * ORCID Profile plugin settings
  *
  *}
-<div id="orcidProfileSettings">
-
-<p id="description">
-	{translate key="plugins.generic.orcidProfile.manager.settings.description" }
-</p>
 
 <script>
 	$(function() {ldelim}
@@ -24,35 +19,40 @@
 </script>
 
 <form class="pkp_form" id="orcidProfileSettingsForm" method="post" action="{url router=$smarty.const.ROUTE_COMPONENT op="manage" category="generic" plugin=$pluginName verb="settings" save=true}">
-	{csrf}
-	{include file="controllers/notification/inPlaceNotification.tpl" notificationId="orcidProfileSettingsFormNotification"}
-	{fbvFormArea id="orcidApiSettings" title="plugins.generic.orcidProfile.manager.settings.title"}
-		{fbvFormSection}
-			{if $globallyConfigured}
-			<p>
-				{translate key="plugins.generic.orcidProfile.manager.settings.description.globallyconfigured"}
-			</p>
-			{/if}
-			{fbvElement id="orcidProfileAPIPath" type="select" translate="true" from=$orcidApiUrls selected=$orcidProfileAPIPath required="true" label="plugins.generic.orcidProfile.manager.settings.orcidProfileAPIPath" disabled=$globallyConfigured}
-			{fbvElement type="text" id="orcidClientId" value=$orcidClientId required="true" label="plugins.generic.orcidProfile.manager.settings.orcidClientId" maxlength="40" size=$fbvStyles.size.MEDIUM disabled=$globallyConfigured}
-			{if $globallyConfigured}
-				<p>
-					{translate key="plugins.generic.orcidProfile.manager.settings.orcidClientSecret"}: <i>{translate key="plugins.generic.orcidProfile.manager.settings.hidden"}</i>
-				</p>
-			{else}
-				{fbvElement type="text" id="orcidClientSecret" value=$orcidClientSecret required="true" label="plugins.generic.orcidProfile.manager.settings.orcidClientSecret" maxlength="40" size=$fbvStyles.size.MEDIUM disabled=$globallyConfigured}
-			{/if}
-		{/fbvFormSection}
-	{/fbvFormArea}
-	{fbvFormSection for="sendMailToAuthorOnPublication" title="plugins.generic.orcidProfile.manager.settings.mailSectionTitle" list="true"}
-		{fbvElement type="checkbox" name="sendMailToAuthorsOnPublication" label="plugins.generic.orcidProfile.manager.settings.sendMailToAuthorsOnPublication" id="sendMailToAuthorsOnPublication" checked=$sendMailToAuthorsOnPublication}
-	{/fbvFormSection}
-	{fbvFormSection for="logLevel" title="plugins.generic.orcidProfile.manager.settings.logSectionTitle"}
-		<p class="pkp_help">{translate key="plugins.generic.orcidProfile.manager.settings.logLevel.help"}</p>
-		{fbvElement id="logLevel" name="logLevel" type="select" from=$logLevelOptions selected=$logLevel}
-	{/fbvFormSection}
-	{fbvFormButtons}
-</form>
+	<div id="orcidProfileSettings">
 
-<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
-</div>
+		<p id="description">
+			{translate key="plugins.generic.orcidProfile.manager.settings.description" }
+		</p>
+
+		{csrf}
+		{include file="controllers/notification/inPlaceNotification.tpl" notificationId="orcidProfileSettingsFormNotification"}
+		{fbvFormArea id="orcidApiSettings" title="plugins.generic.orcidProfile.manager.settings.title"}
+			{fbvFormSection}
+				{if $globallyConfigured}
+				<p>
+					{translate key="plugins.generic.orcidProfile.manager.settings.description.globallyconfigured"}
+				</p>
+				{/if}
+				{fbvElement id="orcidProfileAPIPath" type="select" translate="true" from=$orcidApiUrls selected=$orcidProfileAPIPath required="true" label="plugins.generic.orcidProfile.manager.settings.orcidProfileAPIPath" disabled=$globallyConfigured}
+				{fbvElement type="text" id="orcidClientId" value=$orcidClientId required="true" label="plugins.generic.orcidProfile.manager.settings.orcidClientId" maxlength="40" size=$fbvStyles.size.MEDIUM disabled=$globallyConfigured}
+				{if $globallyConfigured}
+					<p>
+						{translate key="plugins.generic.orcidProfile.manager.settings.orcidClientSecret"}: <i>{translate key="plugins.generic.orcidProfile.manager.settings.hidden"}</i>
+					</p>
+				{else}
+					{fbvElement type="text" id="orcidClientSecret" value=$orcidClientSecret required="true" label="plugins.generic.orcidProfile.manager.settings.orcidClientSecret" maxlength="40" size=$fbvStyles.size.MEDIUM disabled=$globallyConfigured}
+				{/if}
+			{/fbvFormSection}
+		{/fbvFormArea}
+		{fbvFormSection for="sendMailToAuthorOnPublication" title="plugins.generic.orcidProfile.manager.settings.mailSectionTitle" list="true"}
+			{fbvElement type="checkbox" name="sendMailToAuthorsOnPublication" label="plugins.generic.orcidProfile.manager.settings.sendMailToAuthorsOnPublication" id="sendMailToAuthorsOnPublication" checked=$sendMailToAuthorsOnPublication}
+		{/fbvFormSection}
+		{fbvFormSection for="logLevel" title="plugins.generic.orcidProfile.manager.settings.logSectionTitle"}
+			<p class="pkp_help">{translate key="plugins.generic.orcidProfile.manager.settings.logLevel.help"}</p>
+			{fbvElement id="logLevel" name="logLevel" type="select" from=$logLevelOptions selected=$logLevel}
+		{/fbvFormSection}
+		{fbvFormButtons}
+		<p><span class="formRequired">{translate key="common.requiredField"}</span></p>
+	</div>
+</form>


### PR DESCRIPTION
Moved all the content into the <form> tag to avoid displaying duplicated content in case there's a submit error (pkp/pkp-lib#4533)