### PR TITLE
pkp/pkp-lib#4998: Enable editorialAction hook only if email option is enabled.

### DIFF
--- a/OrcidProfilePlugin.inc.php
+++ b/OrcidProfilePlugin.inc.php
@@ -70,7 +70,9 @@ class OrcidProfilePlugin extends GenericPlugin {
 			HookRegistry::register('IssueGridHandler::publishIssue', array($this, 'handlePublishIssue'));
 			HookRegistry::register('issueentrypublicationmetadataform::execute', array($this, 'handleScheduleForPublication'));
 			// Send emails to authors without authorised ORCID access on promoting a submission to production
-			HookRegistry::register('EditorAction::recordDecision', array($this, 'handleEditorAction'));
+			if ($this->getSetting($mainContextId, 'sendMailToAuthorOnPublication')) {
+				HookRegistry::register('EditorAction::recordDecision', array($this, 'handleEditorAction'));
+			}
 		}
 		return $success;
 	}


### PR DESCRIPTION
To resolve pkp/pkp-lib#4998.
