### PR TITLE
pkp/pkp-lib#4998: find current context if main context id is missing

### DIFF
--- a/OrcidProfilePlugin.inc.php
+++ b/OrcidProfilePlugin.inc.php
@@ -70,7 +70,8 @@ class OrcidProfilePlugin extends GenericPlugin {
 			HookRegistry::register('IssueGridHandler::publishIssue', array($this, 'handlePublishIssue'));
 			HookRegistry::register('issueentrypublicationmetadataform::execute', array($this, 'handleScheduleForPublication'));
 			// Send emails to authors without authorised ORCID access on promoting a submission to production
-			if ($this->getSetting($mainContextId, 'sendMailToAuthorOnPublication')) {
+			$contextId = ($mainContextId === null) ? $this->getCurrentContextId() : $mainContextId;
+			if ($this->getSetting($contextId, 'sendMailToAuthorOnPublication')) {
 				HookRegistry::register('EditorAction::recordDecision', array($this, 'handleEditorAction'));
 			}
 		}


### PR DESCRIPTION
Again, to resolve pkp/pkp-lib#4998.  Looking for testing in this forum thread:
https://forum.pkp.sfu.ca/t/ojs-3-1-2-1-orcid-collect-letters-cannot-be-disabled/55206/4?u=ctgraham