### PR TITLE
Complete es_ES translation

### DIFF
--- a/locale/es_ES/locale.xml
+++ b/locale/es_ES/locale.xml
@@ -34,4 +34,38 @@
 	<message key="plugins.generic.orcidProfile.authFailure">OJS no puede comunicarse con el servicio ORCID. Contacte con el administrador/a de la revista e indique su nombre, identificador ORCID y los detalles del envío.</message>
 	<message key="plugins.generic.orcidProfile.fieldset">ORCID</message>
 	<message key="plugins.generic.orcidProfile.connect">Crear o conectar su identificador ORCID</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.title">Configuración de la API de ORCID</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.hidden">oculto</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.description.globallyconfigured">La API de ORCID fue configurada globalmente. Las siguientes credenciales han sido almacenadas.</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.orcidScope">Alcance de acceso del perfil</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.mailSectionTitle">Opciones de e-mail</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.sendMailToAuthorsOnPublication">Enviar e-mail para solicitar a ORCID autorización por parte de los autores de artículos al publicarse un nuevo número</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.logSectionTitle">Registro de solicitudes de ORCID</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.logLevel.help">Seleccione el nivel de registro que debe generar el plugin</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.logLevel.error">Errores</message>
+	<message key="plugins.generic.orcidProfile.manager.settings.logLevel.all">Todo</message>
+	<message key="plugins.generic.orcidProfile.author.accessDenied">El acceso ORCID fue denegado en </message>
+	<message key="plugins.generic.orcidProfile.author.accessTokenStored">Se otorgó acceso al registro ORCID con alcance {$orcidAccessScope}, válido hasta </message>
+	<message key="plugins.generic.orcidProfile.author.requestAuthorization">Enviar e-mail para solicitar autorización de ORCID del contribuyente</message>
+	<message key="plugins.generic.orcidProfile.author.deleteORCID">Eliminar iD ORCID y token de acceso!</message>
+	<message key="plugins.generic.orcidProfile.author.orcidEmptyNotice">Ver a continuación para solicitar un iD de ORCID autenticado</message>
+	<message key="plugins.generic.orcidProfile.author.unauthenticated">El iD ORCID no fue autenticado! Por favor solicite una autenticación del contribuyente.</message>
+	<message key="plugins.generic.orcidProfile.verify.title">Autorización ORCID</message>
+	<message key="plugins.generic.orcidProfile.verify.sendSubmissionToOrcid.success">El envío ha sido incorporado a su registro ORCID</message>
+	<message key="plugins.generic.orcidProfile.verify.sendSubmissionToOrcid.failure">El envío no pudo incorporarse a su registro ORCID.</message>
+	<message key="plugins.generic.orcidProfile.verify.sendSubmissionToOrcid.notpublished">El envío será incorporado a su registro ORCID al momento de la publicación.</message>
+	<message key="plugins.generic.orcidProfile.verify.success">Su iD ORCID ha sido verificado y asociado satisfactoriamente con el envío.</message>
+	<message key="plugins.generic.orcidProfile.verify.failure">Su iD ORCID no pudo ser verificado. En enlace ya no es válido.</message>
+	<message key="plugins.generic.orcidProfile.verify.duplicateOrcid">Un iD ORCID ya fue almacenado para este envío.</message>
+	<message key="plugins.generic.orcidProfile.verify.denied">Ha denegado el acceso a su registro ORCID.</message>
+	<message key="plugins.generic.orcidProfile.failure.contact">Por favor contacte al gestor de la revista con su nombre, iD ORCID, y los detalles de su envío.</message>
+	<message key="plugins.generic.orcidProfile.authorise">Autorizar y conectar su iD ORCID</message>
+	<message key="plugins.generic.orcidProfile.about.title">¿Qué es ORCID?</message>
+	<message key="plugins.generic.orcidProfile.about.orcidExplanation"><![CDATA[ORCID es una organización independiente sin fines de lucro que le provee un identificador persistente – un iD ORCID – que le permite distinguirse de otros investigadores, y un mecanismo para enlazar los resultados y las actividades de su investigación con su iD. ORCID se integra con muchos sistemas utilizados por editoriales, financiadores, instituciones y otros servicios relacionados con la investigación. Puede ver más acerca de ORCID en  <a href="https://orcid.org">orcid.org</a>.]]></message>
+	<message key="plugins.generic.orcidProfile.about.howAndWhy.title">¿Cómo y por qué recolectamos iD ORCID?</message>
+	<message key="plugins.generic.orcidProfile.about.howAndWhy"><![CDATA[Esta revista recolecta su iD ORCID para que podamos [agregar propósito y distinguir entre API de Miembros y API Pública].   Cuando usted hace clic en el botón "Autorizar" de la ventana emergente de ORCID, le solicitaremos que comparta su iD utilizandu proceso autenticad: ya sea a través de <a href="https://support.orcid.org/hc/en-us/articles/360006897454">un registro de iD ORCID</a> o, si usted ya posee uno, <a href="https://support.orcid.org/hc/en-us/categories/360000661673">iniciando sesión en su cuenta de ORCID</a>, y luego otorgándonos permiso para obtener su iD ORCID. Hacemos esto para asegurarnos que usted está correctamente identificado y para conectar de manera segura con su iD ORCID. <br>
+	 Pueden aprender más en  <a href="https://orcid.org/blog/2017/02/20/whats-so-special-about-signing">Qué tiene de especial iniciar sesión.</a>]]></message>
+	<message key="plugins.generic.orcidProfile.about.display.title">¿Dónde se muestran los iD ORCID?</message>
+	<message key="plugins.generic.orcidProfile.about.display"><![CDATA[Para reconocer que usted ha utilizado su iD y que ha sido autenticado, mostramos el ícono de iD de ORCID <img src="https://orcid.org/sites/default/files/images/orcid_16x16(1).gif" alt="iD icon" width="16" height="16" border="0">  junto a su nombre en la página del artículo de su envío y en su perfil de usuario público.<br>
+		Aprenda más en <a href="https://orcid.org/blog/2013/02/22/how-should-orcid-id-be-displayed">Cómo debería mostrarse un iD ORCID.</a>]]></message>
 </locale>


### PR DESCRIPTION
I think orcidProfile is now fully translated to es_ES.
I am not sure if it's better to say in Spanish "el iD ORCID" or "el iD de ORCID" . While the first option is much common here in Argentina, I am not 100% sure it's that common in the rest or Latin America and Spain.