### PR TITLE
pkp/pkp-lib#6097 Convert CURL to Guzzle

### DIFF
--- a/OrcidProfilePlugin.inc.php
+++ b/OrcidProfilePlugin.inc.php
@@ -863,59 +863,18 @@ class OrcidProfilePlugin extends GenericPlugin {
 			$this->logInfo("$method $url");
 			$this->logInfo("Header: " . var_export($header, true));
 
-			$ch = curl_init($url);
-			curl_setopt_array($ch, [
-				CURLOPT_CUSTOMREQUEST => $method,
-				CURLOPT_POSTFIELDS => $orcidWorkJson,
-				CURLOPT_RETURNTRANSFER => true,
-				CURLOPT_HTTPHEADER => $header
-			]);
-			// Use proxy if configured
-			if ($httpProxyHost = Config::getVar('proxy', 'http_host')) {
-				curl_setopt($ch, CURLOPT_PROXY, $httpProxyHost);
-				curl_setopt($ch, CURLOPT_PROXYPORT, Config::getVar('proxy', 'http_port', '80'));
-				if ($username = Config::getVar('proxy', 'username')) {
-					curl_setopt($ch, CURLOPT_PROXYUSERPWD, $username . ':' . Config::getVar('proxy', 'password'));
-				}
-			}
-
-			$responseHeaders = [];
-			// Needed to correctly process response headers.
-			// This function is called by curl for each received line of the header.
-			// Code from StackOverflow answer here: https://stackoverflow.com/a/41135574/8938233
-			// Thanks to StackOverflow user Geoffrey.
-			curl_setopt($ch, CURLOPT_HEADERFUNCTION,
-				function ($curl, $header) use (&$responseHeaders) {
-					$len = strlen($header);
-					$header = explode(':', $header, 2);
-					if (count($header) < 2) {
-						// ignore invalid headers
-						return $len;
-					}
-
-					$name = strtolower(trim($header[0]));
-					if (!array_key_exists($name, $responseHeaders)) {
-						$responseHeaders[$name] = [trim($header[1])];
-					} else {
-						$responseHeaders[$name][] = trim($header[1]);
-					}
-
-					return $len;
-				}
+			$httpClient = Application::get()->getHttpClient();
+			$response = $httpClient->request(
+				$method,
+				$url,
+				[
+					'headers' => $header,
+					'json' => $orcidWork,
+				]
 			);
-
-			$result = curl_exec($ch);
-
-			if (curl_error($ch)) {
-				$this->logError('Unable to post to ORCID API, curl error: ' . curl_error($ch));
-				curl_close($ch);
-				return false;
-			}
-
-			$httpstatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-			curl_close($ch);
-
+			$httpstatus = $response->getStatusCode();
 			$this->logInfo("Response status: $httpstatus");
+			$responseHeaders = $response->getHeaders();
 
 			switch ($httpstatus) {
 				case 200:
@@ -934,9 +893,9 @@ class OrcidProfilePlugin extends GenericPlugin {
 					break;
 				case 401:
 					// invalid access token, token was revoked
-					$error = json_decode($result);
-					if ($error->error === 'invalid_token') {
-						$this->logError("$error->error_description, deleting orcidAccessToken from author");
+					$error = json_decode($response->getBody(),true);
+					if ($error['error'] === 'invalid_token') {
+						$this->logError($error['error_description'] . ', deleting orcidAccessToken from author');
 						$this->removeOrcidAccessToken($author);
 					}
 					$requestsSuccess[$orcid] = false;
@@ -949,16 +908,16 @@ class OrcidProfilePlugin extends GenericPlugin {
 						$authorDao->updateObject($author);
 						$requestsSuccess[$orcid] = false;
 					} else {
-						$this->logError("Unexpected status $httpstatus response, body: $result");
+						$this->logError("Unexpected status $httpstatus response, body: " . $response->getBody());
 						$requestsSuccess[$orcid] = false;
 					}
 					break;
 				case 409:
-					$this->logError('Work already added to profile, response body: ' . $result);
+					$this->logError('Work already added to profile, response body: ' . $response->getBody());
 					$requestsSuccess[$orcid] = false;
 					break;
 				default:
-					$this->logError("Unexpected status $httpstatus response, body: $result");
+					$this->logError("Unexpected status $httpstatus response, body: " . $response->getBody());
 					$requestsSuccess[$orcid] = false;
 			}
 		}

--- a/pages/OrcidHandler.inc.php
+++ b/pages/OrcidHandler.inc.php
@@ -56,36 +56,27 @@ class OrcidHandler extends Handler {
 		$op = $request->getRequestedOp();
 		$plugin = PluginRegistry::getPlugin('generic', 'orcidprofileplugin');
 		$contextId = ($context == null) ? CONTEXT_ID_NONE : $context->getId();
-
-		// Set up common CURL request details
-		$curl = curl_init();
-		// Use proxy if configured
-		if ($httpProxyHost = Config::getVar('proxy', 'http_host')) {
-			curl_setopt($curl, CURLOPT_PROXY, $httpProxyHost);
-			curl_setopt($curl, CURLOPT_PROXYPORT, Config::getVar('proxy', 'http_port', '80'));
-			if ($username = Config::getVar('proxy', 'username')) {
-				curl_setopt($curl, CURLOPT_PROXYUSERPWD, $username . ':' . Config::getVar('proxy', 'password'));
-			}
-		}
+		$httpClient = Application::get()->getHttpClient();
 
 		// API request: Get an OAuth token and ORCID.
-		curl_setopt_array($curl, array(
-			CURLOPT_URL => $plugin->getSetting($contextId, 'orcidProfileAPIPath') . OAUTH_TOKEN_URL,
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_HTTPHEADER => array('Accept: application/json'),
-			CURLOPT_POST => true,
-			CURLOPT_POSTFIELDS => http_build_query(array(
-				'code' => $request->getUserVar('code'),
-				'grant_type' => 'authorization_code',
-				'client_id' => $plugin->getSetting($contextId, 'orcidClientId'),
-				'client_secret' => $plugin->getSetting($contextId, 'orcidClientSecret')
-			))
-		));
-		if (!($result = curl_exec($curl))) {
-			error_log('ORCID CURL error: ' . curl_error($curl) . ' (' . __FILE__ . ' line ' . __LINE__ . ', URL ' . $url . ')');
+		$response = $httpClient->request(
+			'POST',
+			$url = $plugin->getSetting($contextId, 'orcidProfileAPIPath') . OAUTH_TOKEN_URL,
+			[
+				'form_params' => [
+					'code' => $request->getUserVar('code'),
+					'grant_type' => 'authorization_code',
+					'client_id' => $plugin->getSetting($contextId, 'orcidClientId'),
+					'client_secret' => $plugin->getSetting($contextId, 'orcidClientSecret')
+				],
+				'headers' => ['Accept' => 'application/json'],
+			]
+		);
+		if ($response->getStatusCode() != 200) {
+			error_log('ORCID token URL error: ' . $response->getStatusCode() . ' (' . __FILE__ . ' line ' . __LINE__ . ', URL ' . $url . ')');
 			$orcidUri = $orcid = $accessToken = null;
 		} else {
-			$response = json_decode($result, true);
+			$response = json_decode($response->getBody(),true);
 			$orcid = $response['orcid'];
 			$accessToken = $response['access_token'];
 			$orcidUri = ($plugin->getSetting($contextId, "isSandBox") == true ? ORCID_URL_SANDBOX : ORCID_URL) . $orcid;
@@ -94,42 +85,36 @@ class OrcidHandler extends Handler {
 		switch ($request->getUserVar('targetOp')) {
 			case 'register':
 				// API request: get user profile (for names; email; etc)
-				curl_setopt_array($curl, array(
-					CURLOPT_RETURNTRANSFER => 1,
-					CURLOPT_URL =>	$url = $plugin->getSetting($contextId, 'orcidProfileAPIPath') . ORCID_API_VERSION_URL . urlencode($orcid) . '/' . ORCID_PROFILE_URL,
-					CURLOPT_POST => false,
-					CURLOPT_HTTPHEADER => array(
-						'Accept: application/json',
-						'Authorization: Bearer ' . $accessToken,
-					),
-				));
-				if (!($result = curl_exec($curl))) error_log('ORCID CURL error: ' . curl_error($curl) . ' (' . __FILE__ . ' line ' . __LINE__ . ', URL ' . $url . ')');
-				$info = curl_getinfo($curl);
-				if ($info['http_code'] == 200) {
-					$profileJson = json_decode($result, true);
-				} else {
-					error_log('Unexpected ORCID API response: ' . $info['http_code'] . ' (' . __FILE__ . ' line ' . __LINE__ . ', URL ' . $url . ')');
+				$response = $httpClient->request(
+					'GET',
+					$url = $plugin->getSetting($contextId, 'orcidProfileAPIPath') . ORCID_API_VERSION_URL . urlencode($orcid) . '/' . ORCID_PROFILE_URL,
+					[
+						'headers' => [
+							'Accept' => 'application/json',
+							'Authorization' => 'Bearer ' . $accessToken,
+						],
+					]
+				);
+				if ($response->getStatusCode() != 200) {
+					error_log('ORCID profile URL error: ' . $response->getStatusCode() . ' (' . __FILE__ . ' line ' . __LINE__ . ', URL ' . $url . ')');
 					$profileJson = null;
-				}
+				} else $profileJson = json_decode($response->getBody(),true);
 
 				// API request: get employments (for affiliation field)
-				curl_setopt_array($curl, array(
-					CURLOPT_RETURNTRANSFER => 1,
-					CURLOPT_URL =>	$url = $plugin->getSetting($contextId, 'orcidProfileAPIPath') . ORCID_API_VERSION_URL . urlencode($orcid) . '/' . ORCID_EMPLOYMENTS_URL,
-					CURLOPT_POST => false,
-					CURLOPT_HTTPHEADER => array(
-						'Accept: application/json',
-						'Authorization: Bearer ' . $accessToken,
-					),
-				));
-				if (!($result = curl_exec($curl))) error_log('ORCID CURL error: ' . curl_error($curl) . ' (' . __FILE__ . ' line ' . __LINE__ . ', URL ' . $url . ')');
-				$info = curl_getinfo($curl);
-				if ($info['http_code'] == 200) {
-					$employmentJson = json_decode($result, true);
-				} else {
-					error_log('Unexpected ORCID API response: ' . $info['http_code'] . ' (' . __FILE__ . ' line ' . __LINE__ . ', URL ' . $url . ')');
+				$httpClient->request(
+					'GET',
+					$url = $plugin->getSetting($contextId, 'orcidProfileAPIPath') . ORCID_API_VERSION_URL . urlencode($orcid) . '/' . ORCID_EMPLOYMENTS_URL,
+					[
+						'headers' => [
+							'Accept' => 'application/json',
+							'Authorization' => 'Bearer ' . $accessToken,
+						],
+					]
+				);
+				if ($response->getStatusCode() != 200) {
+					error_log('ORCID employments URL error: ' . $response->getStatusCode() . ' (' . __FILE__ . ' line ' . __LINE__ . ', URL ' . $url . ')');
 					$employmentJson = null;
-				}
+				} else $employmentJson = json_decode($response->getBody(),true);
 
 				// Suppress errors for nonexistent array indexes
 				echo '
@@ -162,8 +147,6 @@ class OrcidHandler extends Handler {
 				break;
 			default: assert(false);
 		}
-
-		curl_close($curl);
 	}
 
 	/**
@@ -235,55 +218,43 @@ class OrcidHandler extends Handler {
 		// fetch the access token
 		$url = $plugin->getSetting($contextId, 'orcidProfileAPIPath').OAUTH_TOKEN_URL;
 
-		$ch = curl_init($url);
-
-		$header = array('Accept: application/json');
-		$postData = http_build_query(array(
+		$httpClient = Application::get()->getHttpClient();
+		$header = ['Accept' => 'application/json'];
+		$postData = [
 			'code' => $request->getUserVar('code'),
 			'grant_type' => 'authorization_code',
 			'client_id' => $plugin->getSetting($contextId, 'orcidClientId'),
 			'client_secret' => $plugin->getSetting($contextId, 'orcidClientSecret')
-		));
+		];
 
 		$plugin->logInfo('POST ' . $url);
 		$plugin->logInfo('Request header: ' . var_export($header, true));
-		$plugin->logInfo('Request body: ' . $postData);
+		$plugin->logInfo('Request body: ' . http_build_query($postData));
 
-		// Use proxy if configured
-		if ($httpProxyHost = Config::getVar('proxy', 'http_host')) {
-			curl_setopt($ch, CURLOPT_PROXY, $httpProxyHost);
-			curl_setopt($ch, CURLOPT_PROXYPORT, Config::getVar('proxy', 'http_port', '80'));
-			if ($username = Config::getVar('proxy', 'username')) {
-				curl_setopt($ch, CURLOPT_PROXYUSERPWD, $username . ':' . Config::getVar('proxy', 'password'));
-			}
-		}
-
-		curl_setopt_array($ch, array(
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_HTTPHEADER => $header,
-			CURLOPT_POST => true,
-			CURLOPT_POSTFIELDS => $postData
-		));
-
-		if (!($result = curl_exec($ch))) {
-			$plugin->logError('OrcidHandler::orcidverify - CURL error: ' . curl_error($ch));
+		$response = $httpClient->request(
+			'POST',
+			$url,
+			[
+				'headers' => $header,
+				'form_params' => $postData,
+			]
+		);
+		if ($response->getStatusCode() != 200) {
+			$plugin->logError('OrcidHandler::orcidverify - unexpected response: ' . $response->getStatusCode());
 			$templateMgr->assign('authFailure', true);
 			$templateMgr->display($templatePath);
 			return;
 		}
+		$response = json_decode($response->getBody(),true);
 
-		$httpstatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch);
-
-		$plugin->logInfo('Response body: ' . $result);
-		$response = json_decode($result, true);
+		$plugin->logInfo('Response body: ' . print_r($response,true));
 		if (isset($response['error']) && $response['error'] === 'invalid_grant') {
-			$plugin->logError("Response status: $httpstatus . Authroization code invalid, maybe already used");
+			$plugin->logError("Authorization code invalid, maybe already used");
 			$templateMgr->assign('authFailure', true);
 			$templateMgr->display($templatePath);
 			return;
 		} elseif (isset($response['error'])) {
-			$plugin->logError("Response status: $httpstatus . Invalid ORCID response: $result");
+			$plugin->logError("Invalid ORCID response: $result");
 			$templateMgr->assign('authFailure', true);
 			$templateMgr->display($templatePath);
 		}
@@ -344,10 +315,11 @@ class OrcidHandler extends Handler {
 		$userOrAuthor->setData('orcidAccessExpiresOn', $orcidAccessExpiresOn->toDateTimeString());
 	}
 
-	/*
+	/**
 	 * Show explanation and information about ORCID
+	 * @param $args array
+	 * @param $request PKPRequest
 	 */
-
 	function about($args, $request) {
 		$context = $request->getContext();
 		$contextId = ($context == null) ? CONTEXT_ID_NONE : $context->getId();


### PR DESCRIPTION
@withanage, this PR converts CURL uses to Guzzle. A few notes:
- This will only work with the `master` branch of OJS. I've created a `stable-3_2_1` branch in `pkp/orcidProfile` for compatibility with 3.2.1. (Generally we should have plugin branches that match the same names as the stable branches of the applications they're compatible with -- this will become more important as plugin testing gets more automated.)
- I've tested a basic interaction (pre-filling the registration form) but nothing more -- could you test anything else e.g. the member API interaction?
- It looks like the integration tests are not set up to run via Travis. Could you experiment with that? You'll need a `.travis.yml` -- see e.g. https://github.com/pkp/staticPages/blob/master/.travis.yml.