### PR TITLE
Removes the Javascript dependendency for the orcid Image and adds it to the frontend.

### DIFF
--- a/cypress/tests/functional/01-Orcid-Setup.spec.js
+++ b/cypress/tests/functional/01-Orcid-Setup.spec.js
@@ -11,8 +11,7 @@ describe("Test Orcid Plugin", function () {
 		it('Configure Plugin', function () {
 
 			cy.login('admin', 'admin', 'publicknowledge');
-			cy.get('ul[id="navigationPrimary"] a:contains("Settings")').click();
-			cy.get('ul[id="navigationPrimary"] a:contains("Website")').click();
+			cy.get('li a:contains("Website")').click();
 			cy.get('button[id="plugins-button"]').click();
 			cy.get('input[id^="select-cell-orcidprofileplugin-enabled"]').check();
 			cy.get('#component-grid-settings-plugins-settingsplugingrid-category-generic-row-orcidprofileplugin > .first_column > .show_extras').click();


### PR DESCRIPTION
@Vitaliy-1 
I have made the orcidIcon available as a template variable through  the plugin as suggested by Nate in the following 

PR https://github.com/pkp/orcidProfile/issues/144

I have seen you are adding the orcidIcon using a custom  function in oldGregg Theme , so this can allow duplication of the  icon if you are using $orcidIcon. I am not sure, which other themes are using it. 
This snippet will allow displaying the orcidIcon without custom modifications.

This change is  only reflected in the master branch.

```
{if $author->getData('orcid')}
<span class="orcid">
	{$orcidIcon}
	<a href="{$author->getData('orcid')|escape}" target="_blank">
		{$author->getData('orcid')|escape}
	</a>
</span>
{/if}
```