### PR TITLE
Add option to provide a custom Orcid redirect URI

### DIFF
--- a/OrcidProfilePlugin.inc.php
+++ b/OrcidProfilePlugin.inc.php
@@ -374,7 +374,7 @@ class OrcidProfilePlugin extends GenericPlugin {
 		
 		// overwrite redirect base url if variable is provided in config.inc.php
 		$orcidRedirectBaseUrl = Config::getVar('orcidProfilePlugin', 'orcid_redirect_base_url');
-		if (!ValidatorFactory::make([$orcidRedirectBaseUrl], [['url']])->fails()) {
+		if (!ValidatorFactory::make([$orcidRedirectBaseUrl], [['required','url']])->fails()) {
 			$redirectUrl = preg_replace("#^https{0,1}:\/\/(.*)\/#U", $orcidRedirectBaseUrl, $redirectUrl);
 		}
 

--- a/OrcidProfilePlugin.inc.php
+++ b/OrcidProfilePlugin.inc.php
@@ -371,6 +371,12 @@ class OrcidProfilePlugin extends GenericPlugin {
 		// Use the Dispatcher to construct the url and set the page router.
 		$redirectUrl = $request->getDispatcher()->url($request, ROUTE_PAGE, null, 'orcidapi',
 			$handlerMethod, null, $redirectParams);
+		
+		// overwrite redirect base url if variable is provided in config.inc.php
+		$orcidRedirectBaseUrl = Config::getVar('orcidProfilePlugin', 'orcid_redirect_base_url');
+		if (!ValidatorFactory::make([$orcidRedirectBaseUrl], [['url']])->fails()) {
+			$redirectUrl = preg_replace("#^https{0,1}:\/\/(.*)\/#U", $orcidRedirectBaseUrl, $redirectUrl);
+		}
 
 		return $this->getOauthPath() . 'authorize?' . http_build_query(
 				array(

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ Licensed under GPLv3. See LICENSE.txt for details.
 
 Use the Plugin Gallery from within your PKP application to install the plugin. For further information refer to [PKP|DOCS](https://docs.pkp.sfu.ca/orcid/en/installation-setup).
 
+### Setting a custom rediret URI
+
+In case your Orcid redirect URI does not correspond to your journal base Url (e.g. you may use a centralized redirect server if you have one institutional Orcid account but are running multiple journals on different domains) you may add a variable to the OJS config.inc.php file to overwrite the default redirect base Url. To do this add the following to the end of your config.inc.php file:
+
+```
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Orcid Profile Plugin Settings ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[orcidProfilePlugin]
+
+; Example:
+; orcid_redirect_base_url = "https://my_orcid_redirect.url/"
+orcid_redirect_base_url = ""
+```
+
 ## Debugging/Testing
 
 ### Settings

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Licensed under GPLv3. See LICENSE.txt for details.
 
 Use the Plugin Gallery from within your PKP application to install the plugin. For further information refer to [PKP|DOCS](https://docs.pkp.sfu.ca/orcid/en/installation-setup).
 
-### Setting a custom rediret URI
+### Setting a custom redirect URI
 
 In case your Orcid redirect URI does not correspond to your journal base Url (e.g. you may use a centralized redirect server if you have one institutional Orcid account but are running multiple journals on different domains) you may add a variable to the OJS config.inc.php file to overwrite the default redirect base Url. To do this add the following to the end of your config.inc.php file:
 


### PR DESCRIPTION
At our institution we run multiple journals with individual domains and want to provide the orcidProfile plugin via a single institutional Orcid account. Since Orcid as a default only provides slots to configure up to 5 redirect URIs we need to run a custom Orcid redirect server.

In this case the redirect base url is different from the journal base url. This PR adds an option to provide a custom Orcid redirect base URI. It simply replaces the default base url in the redirect URI generate by the plugin.