### PR TITLE
Fix retrieval of article DOI for transfer to author's ORCID record

### DIFF
--- a/OrcidProfilePlugin.inc.php
+++ b/OrcidProfilePlugin.inc.php
@@ -1122,8 +1122,7 @@ class OrcidProfilePlugin extends GenericPlugin {
 				$pubIdType = $plugin->getPubIdType();
 
 				# Add article ids
-				$pubId = $publication->getData($pubIdType);
-
+				$pubId = $publication->getStoredPubId($pubIdType);
 				if ($pubId) {
 					$externalIds[] = [
 						'external-id-type' => self::PUBID_TO_ORCID_EXT_ID[$pubIdType],

--- a/pages/OrcidHandler.inc.php
+++ b/pages/OrcidHandler.inc.php
@@ -176,11 +176,13 @@ class OrcidHandler extends Handler {
 		$context = $request->getContext();
 		$contextId = ($context == null) ? CONTEXT_ID_NONE : $context->getId();
 
+		/** @var OrcidProfilePlugin $plugin */
 		$plugin = PluginRegistry::getPlugin('generic', 'orcidprofileplugin');
 		$templatePath = $plugin->getTemplateResource(self::TEMPLATE);
 
 
 		$publicationId = $request->getUserVar('state');
+		/** @var AuthorDAO $authorDao */
 		$authorDao = DAORegistry::getDAO('AuthorDAO');
 		$authors = $authorDao->getByPublicationId($publicationId);
 
@@ -294,7 +296,7 @@ class OrcidHandler extends Handler {
 			return;
 		}
 		// Set the orcid id using the full https uri
-		$orcidUri = ($plugin->isSandBox() ? ORCID_URL_SANDBOX : ORCID_URL) . $response['orcid'];
+		$orcidUri = ($plugin->isSandbox() ? ORCID_URL_SANDBOX : ORCID_URL) . $response['orcid'];
 		if (!empty($authorToVerify->getOrcid()) && $orcidUri != $authorToVerify->getOrcid()) {
 			// another ORCID id is stored for the author
 			$templateMgr->assign('duplicateOrcid', true);


### PR DESCRIPTION
Hi everyone,

I found a bug in the stable branch for OJS 3.2.1. It was reported by Dr. Katrin Bemmann that the DOI was not transmitted to the ORCID record of the author but only the URL of the article for articles submitted in our journal hosting instance https://journals.ub.uni-heidelberg.de/

It seems in the changes for the 3.2.1 version a bug was introduced which changed how the the assigned DOI from the Publication object was retrieved (see commit for details).

With the change the DOI is again correctly added to the JSON object for `external-ids` and sent to the ORCID API.

Best regards,

Nils Stefan Weiher
