### PR TITLE
re-added necessary authorFormFilter method for adding contributor from quicksubmit

### DIFF
--- a/OrcidProfilePlugin.php
+++ b/OrcidProfilePlugin.php
@@ -620,6 +620,27 @@ class OrcidProfilePlugin extends GenericPlugin
     }
 
     /**
+     * Output filter adds ORCiD interaction to contributors metadata add/edit form.
+     *
+     * @param $output string
+     * @param $templateMgr TemplateManager
+     * @return string
+     */
+    function authorFormFilter($output, $templateMgr) {
+        if (preg_match('/<input[^>]+name="submissionId"[^>]*>/', $output, $matches, PREG_OFFSET_CAPTURE)) {
+            $match = $matches[0][0];
+            $offset = $matches[0][1];
+            $templateMgr->assign('orcidIcon', $this->getIcon());
+            $newOutput = substr($output, 0, $offset + strlen($match));
+            $newOutput .= $templateMgr->fetch($this->getTemplateResource('authorFormOrcid.tpl'));
+            $newOutput .= substr($output, $offset + strlen($match));
+            $output = $newOutput;
+            $templateMgr->unregisterFilter('output', [$this, 'authorFormFilter']);
+        }
+        return $output;
+    }
+
+    /**
      * Hook callback: register output filter for user registration and article display.
      *
      * @param string $hookName


### PR DESCRIPTION
Method authorFormFilter removed as part of code cleanup for 3.3 - 3.4 upgrade (https://github.com/withanage/orcidProfile/commit/8d66d49649c6f12bbf7ef3ed95c62ae9865750f5#diff-c62bbbc2439724bd77f83a6cf1886cdf24c5eff8207e010372ac84b94c68b91e). But this is used by quicksubmit and also the function call exists in the file