### PR TITLE
Adds verification to context variable if its an instance of Journal c…

### DIFF
--- a/OrcidProfilePlugin.php
+++ b/OrcidProfilePlugin.php
@@ -764,7 +764,7 @@ class OrcidProfilePlugin extends GenericPlugin
         $context = $request->getContext();
 
         // This should only ever happen within a context, never site-wide.
-        if ($context != null) {
+        if ($context != null && $context instanceof Journal) {
             $contextId = $context->getId();
             $publicationId = $author->getData('publicationId');
             $publication = Repo::publication()->get($publicationId);


### PR DESCRIPTION
This modification verifies that the $context is of type Journal.

This fixes this error: 

[17-Apr-2024 14:09:43 America/Argentina/Cordoba] Slim Application Error:
Type: TypeError
Message: APP\plugins\generic\orcidProfile\mailables\OrcidCollectAuthorId::__construct(): Argument #1 ($context) must be of type APP\journal\Journal, APP\server\Server given, called in /home/paideias/preprints.latarxiv.org/plugins/generic/orcidProfile/OrcidProfilePlugin.php on line 898
File: /home/paideias/preprints.latarxiv.org/plugins/generic/orcidProfile/mailables/OrcidCollectAuthorId.php
Line: 38
Trace: #0 /home/paideias/preprints.latarxiv.org/plugins/generic/orcidProfile/OrcidProfilePlugin.php(898): APP\plugins\generic\orcidProfile\mailables\OrcidCollectAuthorId->__construct()
#1 /home/paideias/preprints.latarxiv.org/plugins/generic/orcidProfile/OrcidProfilePlugin.php(862): APP\plugins\generic\orcidProfile\OrcidProfilePlugin->sendAuthorMail()
#2 [internal function]: APP\plugins\generic\orcidProfile\OrcidProfilePlugin->handleAuthorFormExecute()
